### PR TITLE
Adding User Type to the Django Admin

### DIFF
--- a/pnk_server/users/admin.py
+++ b/pnk_server/users/admin.py
@@ -1,8 +1,30 @@
 from django.contrib import admin
-from django.contrib.auth.admin import UserAdmin
 from .models import User
+from .forms import UserAdminForm
+from .choices import USER_TYPES
+
+
+class UserTypeFilter(admin.SimpleListFilter):
+    title = 'User Type'
+    parameter_name = 'User Type'
+
+    def lookups(self, request, model_admin):
+        return USER_TYPES
+
+    def queryset(self, request, queryset):
+        if self.value():
+            return queryset.filter(user_type__exact=self.value())
+        else:
+            return queryset
 
 
 @admin.register(User)
-class UserAdmin(UserAdmin):
-    pass
+class UserAdmin(admin.ModelAdmin):
+    form = UserAdminForm
+    search_fields = ('username', 'first_name', 'last_name', 'email', 'user_type',)
+    list_display = ('username', 'first_name', 'last_name', 'email', 'user_type',)
+    list_filter = (UserTypeFilter,)
+
+    class Meta:
+        model = User
+

--- a/pnk_server/users/choices.py
+++ b/pnk_server/users/choices.py
@@ -1,0 +1,4 @@
+USER_TYPES = (
+    ('MEM', 'Member'),
+    ('AFF', 'Affiliate'),
+)

--- a/pnk_server/users/forms.py
+++ b/pnk_server/users/forms.py
@@ -1,0 +1,23 @@
+from django import forms
+from .models import User
+from .choices import USER_TYPES
+
+
+class UserAdminForm(forms.ModelForm):
+    user_type = forms.ChoiceField(
+        choices=USER_TYPES,
+        label="User Type",
+        initial='',
+        widget=forms.Select(),
+        required=False
+    )
+
+    class Meta:
+        model = User
+        fields = (
+            'username',
+            'first_name',
+            'last_name',
+            'email',
+            'user_type',
+        )

--- a/pnk_server/users/models.py
+++ b/pnk_server/users/models.py
@@ -6,18 +6,13 @@ from django.contrib.auth.models import AbstractUser
 from django.utils.encoding import python_2_unicode_compatible
 from django.db.models.signals import post_save
 from rest_framework.authtoken.models import Token
+from .choices import USER_TYPES
 
 
 @python_2_unicode_compatible
 class User(AbstractUser):
-
-    EMPLOYEE_TYPES = (
-        ('MEM', 'Member'),
-        ('AFF', 'Affiliate'),
-    )
-
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    user_type = models.CharField(max_length=3, choices=EMPLOYEE_TYPES, default='AFF')
+    user_type = models.CharField(max_length=3, choices=USER_TYPES, default='AFF')
 
     def __str__(self):
         return self.username


### PR DESCRIPTION
### Reference Issue

<!-- Link to the GitHub Issue -->
https://github.com/RomzaLabs/pnk_server/issues/17

### Description

<!-- A brief description of what is changing and why. -->
The default User form didn't have the custom fields I added. Created a UserAdminForm for this. While I was at it, I added a filter to quickly filter out affiliates, and moved choices to a separate file.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)


### Changes
<!-- Checklist of proposed changes. To mark a change as complete, put an 'x' in the box. -->
- [x] Created `UserAdmin`.
- [x] Created `choices` file.
- [x] Created `UserAdminForm`.
- [x] Modified `User` model to use the `choices` file.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Review
<!-- Checklist of peers to review and test the code. Recommend including a due date. -->
N/A

